### PR TITLE
Rename docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
+name: nge
+
 services:
   postgres:
+    container_name: nge-postgres
     image: postgres:15
     environment:
       - POSTGRES_USER=netzgrafikeditor
@@ -10,6 +13,7 @@ services:
 
 
   keycloak:
+    container_name: nge-keycloak
     image: quay.io/keycloak/keycloak:23.0
     # as we need to access keycloak from backend Docker container under docker internal port, we need to start Keycloak on 8081, port forwarding in Docker run is not enough
     command: start-dev --import-realm --http-port 8081 --hostname localhost
@@ -23,6 +27,7 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=netzgrafikeditor
 
   keycloak-healthcheck:
+    container_name: nge-keycloak-healthcheck
     image: busybox
     depends_on:
       keycloak:
@@ -36,6 +41,7 @@ services:
 
 
   backend:
+    container_name: nge-backend
     build: backend
     entrypoint: /bin/bash
     command: >
@@ -54,7 +60,9 @@ services:
       interval: 5s
       timeout: 10s
       retries: 15
+
   frontend:
+    container_name: nge-frontend
     image: ghcr.io/schweizerischebundesbahnen/netzgrafik-editor-frontend:2.9.11
     # set platform as necessary:
     platform: linux/x86_64


### PR DESCRIPTION
Because the name of the network, `netzgrafik-editor-docker-compose`, and the children containers, `netzgrafik-editor-docker-compose-keycloak-healthcheck` are quite long, I propose the rename them as following:
- network: `nge`
- postgres: `nge-postgres`
- keycloack-healthcheck: `nge-keycloak-healthcheck`
- keycloack: `nge-keycloack`
- backend: `nge-backend`
- frontend: `nge-frontend`